### PR TITLE
(Kinda) Rewrite auto-spawner + check for light_environment

### DIFF
--- a/lua/autorun/cl_shadows.lua
+++ b/lua/autorun/cl_shadows.lua
@@ -5,6 +5,7 @@ sssssssssssss	dd
 --]]
 
 CreateClientConVar( "csm_spawnalways", 0,  true, false )
+CreateClientConVar( "csm_spawnwithlightenv", 0,  true, false )
 CreateClientConVar( "csm_propradiosity", 4,  true, false )
 CreateClientConVar( "csm_blobbyao", 0,  true, false )
 CreateClientConVar( "csm_wakeprops", 1,  true, false )
@@ -22,6 +23,7 @@ CreateClientConVar(	"csm_perfmode", 0,  true, false)
 
 local ConVarsDefault = {
 	csm_spawnalways = "0",
+	csm_spawnwithlightenv = "0",
 	csm_propradiosity = "4",
 	csm_blobbyao = "0",
 	csm_wakeprops = "1",

--- a/lua/autorun/sv_shadows.lua
+++ b/lua/autorun/sv_shadows.lua
@@ -23,7 +23,7 @@ if (SERVER) then
 		csm_ent:Spawn()
 	end
 
-	function spawnCSM() -- TODO: find out why the spawn with lightenv convar resets every game reload (not cleanup) ~starundrscre
+	function spawnCSM()
 		local spawnEnabled = GetConVar( "csm_spawnalways" )
 		local envCheckToggle = GetConVar( "csm_spawnwithlightenv" )
 		local lightEnvExists

--- a/lua/autorun/sv_shadows.lua
+++ b/lua/autorun/sv_shadows.lua
@@ -45,6 +45,12 @@ if (SERVER) then
 				actualSpawn()
 			end
 		end
+
+		if (GetConVar( "csm_stormfoxsupport" ):GetBool() == true) and (spawnEnabled:GetBool() == false) then
+			for k, v in ipairs(ents.FindByClass( "light_environment" )) do
+				v:Fire("turnon")
+			end
+		end
 	end
 	util.AddNetworkString( "cool_addon_client_ready" )
 

--- a/lua/autorun/sv_shadows.lua
+++ b/lua/autorun/sv_shadows.lua
@@ -41,7 +41,7 @@ if (SERVER) then
 				if lightEnvExists == true then
 					actualSpawn()
 				end
-			elseif lightEnvExists == false then
+			elseif envCheckToggle:GetBool() == false then
 				actualSpawn()
 			end
 		end


### PR DESCRIPTION
Adds in an optional check for `light_environment` in maps, and spawns CSM if it does.
![gmod_A0z1yeykRf](https://user-images.githubusercontent.com/53362212/179380161-25cbd43e-2e0d-4a99-8907-b70a9ad66cfc.png)

Convar: `csm_spawnwithlightenv 0 or 1`
Works in singleplayer and multiplayer, with and without Stormfox

**NOTE:** I didn't add the option to toggle the `light_environment` check during first-time setup (since I haven't really worked with GMod's UI code)