### PR TITLE
Changed 0.001 ortho to `SetEnableShadows` call

### DIFF
--- a/lua/realcsm/skyboxlamp.lua
+++ b/lua/realcsm/skyboxlamp.lua
@@ -112,7 +112,7 @@ local function onPreDrawSkyBox()
 			if IsValid(lpt) and i ~= SKY_LAMP_IDX then
 				local _, l, r, t, b = lpt:GetOrthographic()
 				_savedOrthos[i] = (l + r + t + b) / 4
-				lpt:SetOrthographic(true, 0.001, 0.001, 0.001, 0.001)
+				lpt:SetEnableShadows(false)
 				lpt:Update()
 			end
 		end
@@ -175,7 +175,7 @@ local function onPostDrawSkyBox()
 		for i, s in pairs(_savedOrthos) do
 			local lpt = _lampTable and _lampTable[i]
 			if IsValid(lpt) then
-				lpt:SetOrthographic(true, s, s, s, s)
+				lpt:SetEnableShadows( true )
 				lpt:Update()
 			end
 		end

--- a/lua/realcsm/skyboxlamp.lua
+++ b/lua/realcsm/skyboxlamp.lua
@@ -175,7 +175,7 @@ local function onPostDrawSkyBox()
 		for i, s in pairs(_savedOrthos) do
 			local lpt = _lampTable and _lampTable[i]
 			if IsValid(lpt) then
-				lpt:SetEnableShadows( true )
+				lpt:SetEnableShadows(true)
 				lpt:Update()
 			end
 		end

--- a/lua/realcsm/skyboxlamp.lua
+++ b/lua/realcsm/skyboxlamp.lua
@@ -112,6 +112,7 @@ local function onPreDrawSkyBox()
 			if IsValid(lpt) and i ~= SKY_LAMP_IDX then
 				local _, l, r, t, b = lpt:GetOrthographic()
 				_savedOrthos[i] = (l + r + t + b) / 4
+				lpt:SetOrthographic(true, 0.001, 0.001, 0.001, 0.001)
 				lpt:SetEnableShadows(false)
 				lpt:Update()
 			end
@@ -175,6 +176,7 @@ local function onPostDrawSkyBox()
 		for i, s in pairs(_savedOrthos) do
 			local lpt = _lampTable and _lampTable[i]
 			if IsValid(lpt) then
+				lpt:SetOrthographic(true, s, s, s, s)
 				lpt:SetEnableShadows(true)
 				lpt:Update()
 			end

--- a/lua/realcsm/sunocclude.lua
+++ b/lua/realcsm/sunocclude.lua
@@ -332,7 +332,6 @@ function M.Think(_ignoredViewPos, sunAngle, lampTable)
 					end
 					_savedShadows[i] = pt:GetEnableShadows()
 					pt:SetEnableShadows(false)
-					pt:SetOrthographic(true, 0.001, 0.001, 0.001, 0.001)
 					pt:Update()
 				end
 			end
@@ -361,7 +360,7 @@ function M.Restore(lampTable)
 		if IsValid(pt) then
 			if _savedOrthos[i] then
 				local s = _savedOrthos[i]
-				pt:SetOrthographic(true, s, s, s, s)
+				pt:SetEnableShadows(true)
 				_savedOrthos[i] = nil
 			end
 			-- Restore shadows; default true if we somehow lost the saved value.

--- a/lua/realcsm/sunocclude.lua
+++ b/lua/realcsm/sunocclude.lua
@@ -332,6 +332,7 @@ function M.Think(_ignoredViewPos, sunAngle, lampTable)
 					end
 					_savedShadows[i] = pt:GetEnableShadows()
 					pt:SetEnableShadows(false)
+					pt:SetOrthographic(true, 0.001, 0.001, 0.001, 0.001)
 					pt:Update()
 				end
 			end
@@ -361,6 +362,7 @@ function M.Restore(lampTable)
 			if _savedOrthos[i] then
 				local s = _savedOrthos[i]
 				pt:SetEnableShadows(true)
+				pt:SetOrthographic(true, s, s, s, s)
 				_savedOrthos[i] = nil
 			end
 			-- Restore shadows; default true if we somehow lost the saved value.


### PR DESCRIPTION
Lamps with ortho projection of `0.001` continue to use shadow maps in engine and do not release them. Using 4/8 shadow maps even when they weren't supposed to be used, while of PVS optimization. Thats why disabling of shadows is necessary.

Sum of calls by [render.RenderFlashlights](https://wiki.facepunch.com/gmod/render.RenderFlashlights) can shows a real number of used shadowmaps.

```lua
local n = 0
render.RenderFlashlights( function() n = n + 1 end )
print( n )
```